### PR TITLE
Support setting the seed value.

### DIFF
--- a/loadtest/loadtester.py
+++ b/loadtest/loadtester.py
@@ -8,6 +8,9 @@ import json
 
 
 def main(search):
+    print 'Using seed: %s' % args.seed
+    random.seed(args.seed)
+
     words = set()
     with open(args.i) as f:
         for line in f:
@@ -90,6 +93,7 @@ if __name__ == '__main__':
     parser.add_argument('--solr', type=str, default=None, help="Solr search URL")
     parser.add_argument('-i', type=str, required=True, help='input file for words')
     parser.add_argument('-o', type=str, required=True, help='output file')
+    parser.add_argument('--seed', type=long, default=long(time.mktime(time.gmtime())), help='seed value')
     parser.add_argument('--ns', type=int, default=1, help='number of searches (default is 1)')
     parser.add_argument('--nt', type=int, default=1, help='number of terms (default is 1)')
     parser.add_argument('--nf', type=int, default=0, help='number of filters (default is 0)')


### PR DESCRIPTION
Allow setting the seed value so the random search terms/filters
can be reproduced in other tests.  Specifically, use this when
comparing Solr and ES so ensure both are using same terms/filters.

Closes #1
